### PR TITLE
Add email templates for 'Send an email', 'Report a problem' and 'Chat with us' buttons

### DIFF
--- a/src/app/help-support/page.tsx
+++ b/src/app/help-support/page.tsx
@@ -45,7 +45,7 @@ const HelpPage: FC<HelpPageProps> = () => {
                 </p>
                 <div className="w-full flex justify-between bg-cardsDark py-2 px-6 rounded-10">
                   <a
-                    href="mailto:support@athleti.fi?subject=Inquiry&body=Dear%20Support%20Team,%0D%0A%0D%0AI%20have%20a%20question%20regarding%20your%20website.%0D%0A%0D%0A[Please%20provide%20more%20details%20about%20your%20inquiry]%0D%0A%0D%0AThank%20you%20for%20your%20assistance.%0D%0A%0D%0ABest%20regards,%0D%0A[Your%20Name]"
+                    href="mailto:send-an-email@athleti.fi?subject=Question%20about%20AthletiFi&body=Dear%20Support%20Team,%0D%0A%0D%0AI%20have%20a%20question%20regarding%20your%20website.%0D%0A%0D%0A[Please%20provide%20more%20details%20about%20your%20inquiry]%0D%0A%0D%0AThank%20you%20for%20your%20assistance.%0D%0A%0D%0ABest%20regards,%0D%0A[Your%20Name]"
                     className="flex my-4"
                   >
                     <FontAwesomeIcon
@@ -56,7 +56,10 @@ const HelpPage: FC<HelpPageProps> = () => {
                       Send an email
                     </p>
                   </a>
-                  <div className="flex my-4">
+                  <a
+                    href="mailto:chat-with-us@athleti.fi?subject=Chat%20Request&body=Dear%20Support%20Team,%0D%0A%0D%0AI%20would%20like%20to%20chat%20with%20a%20representative%20regarding%20a%20question%20I%20have.%0D%0A%0D%0A[Please%20provide%20more%20details%20about%20your%20chat%20request]%0D%0A%0D%0AThank%20you%20for%20your%20assistance.%0D%0A%0D%0ABest%20regards,%0D%0A[Your%20Name]"
+                    className="flex my-4"
+                  >
                     <FontAwesomeIcon
                       icon={faMessage}
                       className="text-skyblue mr-3"
@@ -64,20 +67,24 @@ const HelpPage: FC<HelpPageProps> = () => {
                     <p className="text-primary text-sm md:text-base font-extralight">
                       Chat with us
                     </p>
-                  </div>
+                  </a>
                 </div>
               </div>
               <div className="h-px w-full bg-partnersBorders my-12"></div>
               <div className="">
                 <div className="flex my-4">
-                  {' '}
-                  <FontAwesomeIcon
-                    className="text-skyblue mr-3"
-                    icon={faFlag}
-                  />
-                  <p className="text-primary text-sm md:text-base">
-                    Report a problem
-                  </p>
+                  <a
+                    href="mailto:report-a-problem@athleti.fi?subject=Problem%20Report&body=Description%20of%20the%20Problem:%0D%0A[Please%20describe%20the%20problem%20you%20encountered%20in%20detail]%0D%0A%0D%0AWhat%20were%20you%20trying%20to%20do%20when%20the%20problem%20occurred?%0D%0A[Explain%20what%20you%20were%20attempting%20to%20do%20on%20the%20website]%0D%0A%0D%0AWhat%20did%20you%20expect%20to%20happen?%0D%0A[Describe%20what%20you%20thought%20should%20have%20happened]%0D%0A%0D%0AWhat%20actually%20happened?%0D%0A[Describe%20what%20occurred%20instead]%0D%0A%0D%0AAny%20additional%20information%20that%20might%20be%20helpful:%0D%0A[Feel%20free%20to%20include%20any%20other%20details,%20such%20as%20screenshots%20or%20links,%20that%20could%20assist%20us%20in%20understanding%20the%20problem]%0D%0A%0D%0AThank%20you%20for%20bringing%20this%20to%20our%20attention.%20We%20appreciate%20your%20help%20in%20improving%20our%20website.%0D%0A%0D%0ABest%20regards,%0D%0A[Your%20Name]"
+                    className="flex my-4"
+                  >
+                    <FontAwesomeIcon
+                      className="text-skyblue mr-3"
+                      icon={faFlag}
+                    />
+                    <p className="text-primary text-sm md:text-base">
+                      Report a problem
+                    </p>
+                  </a>
                 </div>
 
                 <div className="flex items-center cursor-pointer">

--- a/src/app/help-support/page.tsx
+++ b/src/app/help-support/page.tsx
@@ -44,7 +44,10 @@ const HelpPage: FC<HelpPageProps> = () => {
                   Can’t find what you are looking for?
                 </p>
                 <div className="w-full flex justify-between bg-cardsDark py-2 px-6 rounded-10">
-                  <div className="flex my-4">
+                  <a
+                    href="mailto:support@athleti.fi?subject=Inquiry&body=Dear%20Support%20Team,%0D%0A%0D%0AI%20have%20a%20question%20regarding%20your%20website.%0D%0A%0D%0A[Please%20provide%20more%20details%20about%20your%20inquiry]%0D%0A%0D%0AThank%20you%20for%20your%20assistance.%0D%0A%0D%0ABest%20regards,%0D%0A[Your%20Name]"
+                    className="flex my-4"
+                  >
                     <FontAwesomeIcon
                       icon={faPaperPlane}
                       className="text-skyblue mr-3"
@@ -52,7 +55,7 @@ const HelpPage: FC<HelpPageProps> = () => {
                     <p className="text-primary text-sm md:text-base font-extralight">
                       Send an email
                     </p>
-                  </div>
+                  </a>
                   <div className="flex my-4">
                     <FontAwesomeIcon
                       icon={faMessage}


### PR DESCRIPTION
updates the "Send an email", "Chat with us", and "Report a problem" links to open the user's email client with prepopulated subject and body templates.